### PR TITLE
fix(api): add 'token' prefix to Authorization header for BTCPay Green…

### DIFF
--- a/packages/medusa-plugin-btcpay/README.md
+++ b/packages/medusa-plugin-btcpay/README.md
@@ -33,6 +33,8 @@ BTCPAY_STORE_ID=<your store id>
 BTCPAY_WEBHOOK_SECRET=<your webhook secret>
 ```
 
+> The BTCPay Greenfield API requires the Authorization header to include a `token` prefix.
+
 You need to add the provider into your `medusa-config.ts`:
 
 ```typescript
@@ -49,7 +51,8 @@ module.exports = defineConfig({
             id: "btcpayserver",
             options: {
               url: process.env.BTCPAY_URL,
-              apiKey: process.env.BTCPAY_API_KEY,
+              // include "token " prefix before actual apikey.
+              apiKey: `token ${process.env.BTCPAY_API_KEY}`,
               storeId: process.env.BTCPAY_STORE_ID,
               webhookSecret: process.env.BTCPAY_WEBHOOK_SECRET,
             },

--- a/packages/medusa-plugin-btcpay/src/providers/README.md
+++ b/packages/medusa-plugin-btcpay/src/providers/README.md
@@ -34,6 +34,8 @@ BTCPAY_STORE_ID=<your store id>
 BTCPAY_WEBHOOK_SECRET=<your webhook secret>
 ```
 
+> The BTCPay Greenfield API requires the Authorization header to include a `token` prefix.
+
 You need to add the provider into your `medusa-config.ts`:
 
 ```typescript


### PR DESCRIPTION
…field API

The BTCPay Greenfield API requires the Authorisation header to be in the format: 'Authorisation: token {API_KEY}'. This change ensures the correct format is used to prevent authentication errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the BTCPay Greenfield API requires the Authorization header to use a “token ” prefix.
  * Updated configuration examples to prefix the API key with “token ” and added an explanatory note to guide setup.
  * Aligned guidance across plugin and provider docs to reduce authentication errors (e.g., 401) and streamline integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->